### PR TITLE
Criação de rota para criação de Manager no AdminController

### DIFF
--- a/api-hub-inovacao/src/main/java/br/com/apihubinovacao/api/controllers/AdminController.java
+++ b/api-hub-inovacao/src/main/java/br/com/apihubinovacao/api/controllers/AdminController.java
@@ -1,0 +1,32 @@
+package br.com.apihubinovacao.api.controllers;
+
+import br.com.apihubinovacao.domain.dtos.UserCreateCpfDTO;
+import br.com.apihubinovacao.domain.dtos.UserResponseCpfDTO;
+import br.com.apihubinovacao.domain.usecases.user.create.CreateManagerUserUseCase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Controller exclusivo para a criação de Manager (Admin)
+ */
+@RestController
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final CreateManagerUserUseCase createManagerUserUseCase;
+
+    @Autowired
+    public AdminController(CreateManagerUserUseCase createManagerUserUseCase) {
+        this.createManagerUserUseCase = createManagerUserUseCase;
+    }
+
+    /**
+     * Criar um novo Manager
+     */
+    @PostMapping("/create-manager")
+    public ResponseEntity<UserResponseCpfDTO> createManager(@RequestBody UserCreateCpfDTO dto) {
+        UserResponseCpfDTO createdManager = createManagerUserUseCase.execute(dto);
+        return ResponseEntity.ok(createdManager);
+    }
+}

--- a/api-hub-inovacao/src/main/java/br/com/apihubinovacao/api/routes/RouteDefinitions.java
+++ b/api-hub-inovacao/src/main/java/br/com/apihubinovacao/api/routes/RouteDefinitions.java
@@ -21,7 +21,8 @@ public class RouteDefinitions {
     // Rotas acessíveis apenas para administradores
     public static final String[] ADMIN_ROUTES = {
             "/admin/**",
-            "/users/all-platform-users", // Buscar todos os usuários paginados
+            "/users/all-platform-users",
+            "/admin/create-manager"
     };
 
     // Métodos HTTP permitidos para rotas públicas

--- a/api-hub-inovacao/src/main/java/br/com/apihubinovacao/domain/usecases/user/create/CreateManagerUserUseCase.java
+++ b/api-hub-inovacao/src/main/java/br/com/apihubinovacao/domain/usecases/user/create/CreateManagerUserUseCase.java
@@ -1,0 +1,88 @@
+package br.com.apihubinovacao.domain.usecases.user.create;
+
+import br.com.apihubinovacao.domain.dtos.PhoneResponseDTO;
+import br.com.apihubinovacao.domain.dtos.UserCreateCpfDTO;
+import br.com.apihubinovacao.domain.dtos.UserResponseCpfDTO;
+import br.com.apihubinovacao.domain.enums.ErrorCodeEnum;
+import br.com.apihubinovacao.domain.exceptions.BusinessException;
+import br.com.apihubinovacao.domain.models.Manager;
+import br.com.apihubinovacao.domain.repositories.ManagerRepository;
+import br.com.apihubinovacao.domain.services.PhoneService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CreateManagerUserUseCase {
+
+    private final ManagerRepository managerRepository;
+    private final PhoneService phoneService;
+    private final PasswordEncoder passwordEncoder;
+
+    public CreateManagerUserUseCase(
+            ManagerRepository managerRepository,
+            PhoneService phoneService,
+            PasswordEncoder passwordEncoder
+    ) {
+        this.managerRepository = managerRepository;
+        this.phoneService = phoneService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public UserResponseCpfDTO execute(UserCreateCpfDTO dto) {
+        validateManagerInput(dto.email(), dto.password(), dto.cpf());
+
+        Manager manager = createManagerInstance(dto);
+        setManagerFields(manager, dto);
+        Manager savedManager = saveManager(manager);
+
+        return saveAndReturn(savedManager, dto);
+    }
+
+    private void validateManagerInput(String email, String password, String cpf) {
+        if (email == null || email.isEmpty()) throw new BusinessException(ErrorCodeEnum.INVALID_EMAIL);
+        if (password == null || password.isEmpty()) throw new BusinessException(ErrorCodeEnum.INVALID_PASSWORD);
+        if (cpf == null || cpf.isEmpty()) throw new BusinessException(ErrorCodeEnum.INVALID_CPF);
+
+        if (managerRepository.findByEmail(email).isPresent()) {
+            throw new BusinessException(ErrorCodeEnum.EMAIL_ALREADY_EXISTS);
+        }
+    }
+
+    private Manager createManagerInstance(UserCreateCpfDTO dto) {
+        Manager manager = new Manager();
+        manager.setCpf(dto.cpf());
+        return manager;
+    }
+
+    private void setManagerFields(Manager manager, UserCreateCpfDTO dto) {
+        manager.setName(dto.name());
+        manager.setEmail(dto.email());
+
+        String encodedPassword = passwordEncoder.encode(dto.password());
+        manager.setPassword(encodedPassword);
+        manager.setRegistration(dto.registration());
+        manager.setRole(dto.role());
+        manager.setInstitutionOrganization(dto.institutionOrganization());
+        manager.setUserStatus(dto.userStatus());
+    }
+
+    private Manager saveManager(Manager manager) {
+        return managerRepository.save(manager);
+    }
+
+    private UserResponseCpfDTO saveAndReturn(Manager savedManager, UserCreateCpfDTO dto) {
+        List<PhoneResponseDTO> phones = dto.phones().stream()
+                .map(phoneDto -> phoneService.createPhone(phoneDto, savedManager))
+                .collect(Collectors.toList());
+
+        return new UserResponseCpfDTO(
+                savedManager.getId(), savedManager.getName(), savedManager.getEmail(),
+                savedManager.getRegistration(), savedManager.getRole(),
+                savedManager.getInstitutionOrganization(), savedManager.isUserStatus(),
+                savedManager.getCpf(), phones
+        );
+    }
+}

--- a/api-hub-inovacao/src/main/java/br/com/apihubinovacao/domain/usecases/user/create/CreateUserWithCpfUseCase.java
+++ b/api-hub-inovacao/src/main/java/br/com/apihubinovacao/domain/usecases/user/create/CreateUserWithCpfUseCase.java
@@ -6,11 +6,9 @@ import br.com.apihubinovacao.domain.dtos.UserResponseCpfDTO;
 import br.com.apihubinovacao.domain.enums.ErrorCodeEnum;
 import br.com.apihubinovacao.domain.enums.Role;
 import br.com.apihubinovacao.domain.exceptions.BusinessException;
-import br.com.apihubinovacao.domain.models.Manager;
 import br.com.apihubinovacao.domain.models.Professor;
 import br.com.apihubinovacao.domain.models.Student;
 import br.com.apihubinovacao.domain.models.User;
-import br.com.apihubinovacao.domain.repositories.ManagerRepository;
 import br.com.apihubinovacao.domain.repositories.ProfessorRepository;
 import br.com.apihubinovacao.domain.repositories.StudentRepository;
 import br.com.apihubinovacao.domain.services.PhoneService;
@@ -23,20 +21,17 @@ import java.util.stream.Collectors;
 @Service
 public class CreateUserWithCpfUseCase {
 
-    private final ManagerRepository managerRepository;
     private final StudentRepository studentRepository;
     private final ProfessorRepository professorRepository;
     private final PhoneService phoneService;
     private final PasswordEncoder passwordEncoder;
 
     public CreateUserWithCpfUseCase(
-            ManagerRepository managerRepository,
             StudentRepository studentRepository,
             ProfessorRepository professorRepository,
             PhoneService phoneService,
             PasswordEncoder passwordEncoder
     ) {
-        this.managerRepository = managerRepository;
         this.studentRepository = studentRepository;
         this.professorRepository = professorRepository;
         this.phoneService = phoneService;
@@ -58,19 +53,14 @@ public class CreateUserWithCpfUseCase {
         if (password == null || password.isEmpty()) throw new BusinessException(ErrorCodeEnum.INVALID_PASSWORD);
         if (cpf == null || cpf.isEmpty()) throw new BusinessException(ErrorCodeEnum.INVALID_CPF);
 
-        if (managerRepository.findByEmail(email).isPresent() ||
-                studentRepository.findByEmail(email).isPresent() ||
+        if (studentRepository.findByEmail(email).isPresent() ||
                 professorRepository.findByEmail(email).isPresent()) {
             throw new BusinessException(ErrorCodeEnum.EMAIL_ALREADY_EXISTS);
         }
     }
 
     private User createUserInstance(UserCreateCpfDTO dto) {
-        if (dto.role() == Role.MANAGER) {
-            Manager manager = new Manager();
-            manager.setCpf(dto.cpf());
-            return manager;
-        } else if (dto.role() == Role.STUDENT) {
+        if (dto.role() == Role.STUDENT) {
             Student student = new Student();
             student.setCpf(dto.cpf());
             return student;
@@ -99,8 +89,7 @@ public class CreateUserWithCpfUseCase {
     }
 
     private User saveUser(User user) {
-        if (user instanceof Manager) return managerRepository.save((Manager) user);
-        else if (user instanceof Student) return studentRepository.save((Student) user);
+        if (user instanceof Student) return studentRepository.save((Student) user);
         else return professorRepository.save((Professor) user);
     }
 
@@ -113,9 +102,8 @@ public class CreateUserWithCpfUseCase {
                 savedUser.getId(), savedUser.getName(), savedUser.getEmail(),
                 savedUser.getRegistration(), savedUser.getRole(),
                 savedUser.getInstitutionOrganization(), savedUser.isUserStatus(),
-                savedUser instanceof Manager ? ((Manager) savedUser).getCpf() :
-                        savedUser instanceof Student ? ((Student) savedUser).getCpf() :
-                                ((Professor) savedUser).getCpf(), phones
+                savedUser instanceof Student ? ((Student) savedUser).getCpf() :
+                        ((Professor) savedUser).getCpf(), phones
         );
     }
 }


### PR DESCRIPTION
adiciona a funcionalidade de criação de usuários com o papel de Manager no sistema. A partir de agora, admins podem criar Managers através da nova rota /admin/create-manager.

Mudanças realizadas:
	•	Novo controller: Foi criado o AdminController com uma rota específica para a criação de Manager.
	•	Rota: A rota POST /admin/create-manager foi adicionada para permitir a criação de um Manager via JSON.
	•	UseCase: A criação de Manager agora é manipulada pelo CreateManagerUserUseCase, que valida e salva o usuário com o papel de Manager.
	•	DTO: O DTO utilizado para criação de Manager é o mesmo utilizado para criação de usuários com CPF.

Como testar:
	1.	Verifique a nova rota: Use um cliente HTTP (como Postman ou Insomnia) para enviar um POST para /admin/create-manager com um corpo JSON válido.
	2.	JSON de exemplo:
	
	{
  "name": "Maria Oliveira",
  "email": "maria.oliveira@exemplo.com",
  "password": "senhaForte456",
  "cpf": "98765432100",
  "registration": "MGR98765",
  "role": "MANAGER",
  "institutionOrganization": "Organização ABC",
  "userStatus": true,
  "phones": [
    {
      "number": "11987654321",
      "type": "MOBILE"
    }
  ]
}
	3.	Resposta esperada: O sistema deve retornar o objeto do Manager criado com o status HTTP 200 (OK).

Tarefas realizadas:
	•	Criada nova rota /admin/create-manager no AdminController.
	•	Injetado e utilizado o CreateManagerUserUseCase para manipular a criação do Manager.
	•	Validação e criação do Manager com base no DTO UserCreateCpfDTO.
	•	Adicionada verificação para garantir que o email não seja duplicado no banco de dados.
	
		•	Nenhuma modificação foi realizada nos controllers ou use cases relacionados à criação de Student ou Professor.
	•	Certifique-se de que a role de ADMIN está configurada corretamente para acessar a rota /admin/create-manager.